### PR TITLE
feat(engine): add resources to pod and annotations to ingress

### DIFF
--- a/engine/README.md
+++ b/engine/README.md
@@ -5,9 +5,12 @@ The engine is the beating heart of Podinate. It can take a .pf or Kubernetes man
 A Podfile is an HCL file with a bunch of resources declared in it. Those resources are: 
 - Pod
     - Service
-    - Ingress
+        - Ingress
+            - Annotations
     - Volume
     - Shared Volume 
+    - Environment
+    - Resources
 - Shared Volume
 - Podinate 
     - Contains information about the package and the namespace


### PR DESCRIPTION
## What does this change do?

Adds resources support to the Pod definition. These look like
```hcl
resource "cpu" {
    requests = 256
    limits = 512
}
```
Which is antithetical to the kube schema which looks like
```hcl
Resource {
    Requests {
        cpu: 256
    }
    Limits {
        cpu: 512
    }
}
```

Also adds annotations to the ingress spec. Preferably something more widespread would be done here (since annotations will be everywhere), but right now this is the only use case I have for annotations 😅

They look like:
```hcl
annotation "nginx.ingress.kubernetes.io/whitelist-source-range" {
    value = "192.168.0.0/16"
}
```

Not sure if there is a way to lint this, Go is not my usual working environment.