### PR TITLE
feat(engine): add node port specification & service name validation

### DIFF
--- a/engine/engine_pod.go
+++ b/engine/engine_pod.go
@@ -367,6 +367,9 @@ func (p Pod) GetObjects(ctx context.Context) ([]runtime.Object, error) {
 func (p *Pod) GetServiceObjects(ctx context.Context) ([]runtime.Object, error) {
 	var out []runtime.Object
 	for name, service := range p.Services {
+		if len(name) > 15 {
+			return nil, stderrors.New("service names must be no more than 15 characters")
+		}
 		svcSpec := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -393,6 +396,10 @@ func (p *Pod) GetServiceObjects(ctx context.Context) ([]runtime.Object, error) {
 			svcSpec.Spec.Type = corev1.ServiceType(*service.Type)
 		} else {
 			svcSpec.Spec.Type = corev1.ServiceTypeClusterIP
+		}
+
+		if svcSpec.Spec.Type == corev1.ServiceTypeNodePort {
+			svcSpec.Spec.Ports[0].NodePort = int32(service.Port)
 		}
 
 		if service.Protocol != nil && strings.ToLower(*service.Protocol) == "udp" {


### PR DESCRIPTION
## What does this change do?

- Adds support for explicitly setting the node port via the `port` attribute. This way it doesn't randomly generate a new one.
- Adds a validation that service names are not too long!

If the node port is already in use, it doesn't like it. My plex container has a node port that was provisioned outside of podinate, and it refuses to update that. My kuma container has a node port specified by podinate, and it has no issue with updating it.